### PR TITLE
updates node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Create env"
 description: "Creates a .env file"
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"


### PR DESCRIPTION
In June, GitHub deprecated Node 12. Now all Node 12 actions are forced to run on Node 16.

This action has been running successfully on Node 16, so the only change needed is to update the yaml file to make it clear to devs which node version is being used.

Fixes [CICD-647](https://milkmoney.atlassian.net/browse/CICD-647).

[CICD-647]: https://milkmoney.atlassian.net/browse/CICD-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ